### PR TITLE
Fix NVIDIA Hyprland monitor restore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,12 @@ sh -c "echo --connect,--width,${SUNSHINE_CLIENT_WIDTH},--height,${SUNSHINE_CLIEN
 sh -c "echo --disconnect | socat - UNIX-CONNECT:/tmp/sunshineVD.sock"
 ```
 
+### NVIDIA + Hyprland
+
+On NVIDIA/Hyprland systems, the daemon avoids directly stealing/reassigning CRTCs for physical outputs. Instead, it uses Hyprland monitor commands to hide physical displays while the virtual display is active, then restores the original monitor configuration on disconnect.
+
+The restore state is built from `hyprctl -j monitors`, preserving the live mode, position, scale, bit depth (8-bit/10-bit), and active VRR state reported by Hyprland.
+
 ### Multi-GPU systems
 
 On systems with both an integrated GPU (iGPU) and a discrete GPU (dGPU), the daemon automatically selects the card with the most connected displays. Override with the `-d` flag if it picks the wrong one:
@@ -140,13 +146,16 @@ The dev service uses `Restart=no` so crashes surface immediately rather than bei
 3. Finds the first available empty display slot (prefers DisplayPort, falls back to HDMI)
 4. Overrides EDID for that slot via debugfs
 5. Releases CRTCs from and turns off all connected physical displays
+   - On NVIDIA/Hyprland, uses compositor-safe Hyprland monitor commands instead of direct DRM CRTC stealing
 6. Enables the virtual display
 7. Waits for the compositor to assign a CRTC, or forces one if it doesn't
+   - On NVIDIA/Hyprland, it refuses to force a direct DRM CRTC assignment and aborts instead
 
 ### On Disconnect
 
 1. Daemon receives `--disconnect`
 2. Turns physical displays back on and forces CRTC assignment
+   - On NVIDIA/Hyprland, restores the saved live Hyprland monitor specs from `hyprctl -j monitors`
 3. Releases the CRTC from and turns off the virtual display
 
 ### On Sunshine Crash or Stop

--- a/src/display.py
+++ b/src/display.py
@@ -4,6 +4,7 @@ Connect and disconnect virtual displays by managing EDIDs and sysfs connector st
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -17,10 +18,29 @@ from src.drm import (
     run_command,
     wait_for_output_ready,
 )
+from src.drm.de import hyprland
 from src.drm.de.kwin import clear_kwin_output_config
 from src.edid import create_edid, find_best_vic_resolution, get_pixel_clock_info
 
 SCRIPT_DIR = Path(__file__).parent.parent.absolute()
+
+
+def _card_driver(card_name: str) -> str:
+    """Return the kernel driver/module name for a DRM card, if known."""
+    driver = Path(f"/sys/class/drm/{card_name}/device/driver")
+    try:
+        return driver.resolve().name.lower()
+    except OSError:
+        return ""
+
+
+def _use_hyprland_safe_path(card_name: str) -> bool:
+    """
+    On NVIDIA + Hyprland, direct DRM CRTC stealing/reassignment can leave a
+    physical output stuck at 0x0 after Sunshine disconnects. Prefer compositor
+    monitor commands there; keep the old DRM path for other compositors/drivers.
+    """
+    return "nvidia" in _card_driver(card_name) and hyprland.available()
 
 
 def connect(width: int, height: int, refresh_rate: int, device: str | None = None) -> bool:
@@ -160,18 +180,31 @@ def connect(width: int, height: int, refresh_rate: int, device: str | None = Non
 
     print(f"  ✓ EDID override applied")
 
-    # Step 5: Turn off all connected displays and explicitly release their CRTCs.
-    # On AMD, echo off > status marks the connector disconnected in sysfs but
-    # the compositor keeps the CRTC active.  Without an explicit CRTC release
-    # the compositor continues rendering to the old displays, Sunshine sees
-    # multiple monitors, and uses the wrong one.
-    print("\nStep 5: Turning off connected displays...")
-    for display in connected_displays:
-        _ = release_crtc(card_name, display)
-        status_path = f"/sys/class/drm/{card_name}-{display}/status"
-        cmd = f"sh -c 'echo off > {status_path}'"
-        _ = run_command(cmd)
-        print(f"  ✓ Turned off {display}")
+    hyprland_safe = _use_hyprland_safe_path(card_name)
+    hyprland_restore_specs: dict[str, dict[str, object]] = {}
+
+    if hyprland_safe:
+        print("\nStep 5: NVIDIA/Hyprland detected — using compositor-safe monitor toggles")
+        hyprland_restore_specs = hyprland.monitor_specs(connected_displays)
+        missing_specs = sorted(set(connected_displays) - set(hyprland_restore_specs))
+        if missing_specs:
+            print(f"  Error: Could not capture Hyprland restore state for: {', '.join(missing_specs)}")
+            print("  Refusing to hide physical outputs without a known-good restore plan")
+            return False
+        print("  Physical outputs will be hidden via Hyprland, not by stealing DRM CRTCs")
+    else:
+        # Turn off all connected displays and explicitly release their CRTCs.
+        # On AMD, echo off > status marks the connector disconnected in sysfs but
+        # the compositor keeps the CRTC active.  Without an explicit CRTC release
+        # the compositor continues rendering to the old displays, Sunshine sees
+        # multiple monitors, and uses the wrong one.
+        print("\nStep 5: Turning off connected displays...")
+        for display in connected_displays:
+            _ = release_crtc(card_name, display)
+            status_path = f"/sys/class/drm/{card_name}-{display}/status"
+            cmd = f"sh -c 'echo off > {status_path}'"
+            _ = run_command(cmd)
+            print(f"  ✓ Turned off {display}")
 
     # Step 6: Clear any stale KWin output config, then turn on virtual display
     print(f"\nStep 6: Preparing virtual display ({empty_port})...")
@@ -187,12 +220,19 @@ def connect(width: int, height: int, refresh_rate: int, device: str | None = Non
 
     print(f"  ✓ Virtual display enabled on {empty_port}")
 
-    # Step 7: Wait for compositor to assign CRTC naturally, then fall back to forcing
+    # Step 7: Wait for compositor to assign CRTC naturally, then fall back to forcing.
+    # Do not force with direct DRM on NVIDIA/Hyprland; that is the path that can
+    # leave physical monitors stuck at 0x0 after disconnect.
     print(f"\nStep 7: Waiting for output to be ready...")
     ready, mode = wait_for_output_ready(card_name, empty_port, width, height, timeout=5.0)
 
     if ready:
         print(f"  ✓ Output ready ({mode})")
+    elif hyprland_safe:
+        print("  ✗ Timed out waiting for virtual output; refusing to hide physical outputs")
+        _ = run_command(f"sh -c 'echo off > /sys/class/drm/{card_name}-{empty_port}/status'")
+        _ = run_command(f"sh -c 'cat /dev/null > {edid_override_path}'")
+        return False
     else:
         print(f"  ⚠ Compositor did not assign CRTC — forcing assignment...")
         _ = force_crtc_assignment(card_name, empty_port)
@@ -202,10 +242,22 @@ def connect(width: int, height: int, refresh_rate: int, device: str | None = Non
         else:
             print(f"  ⚠ Timed out waiting for output, proceeding anyway")
 
-    # Save state for disconnect (line 4 = edid_override_path for cleanup)
+    if hyprland_safe and connected_displays:
+        print("\nStep 8: Hiding physical outputs via Hyprland...")
+        if hyprland.disable_outputs(connected_displays):
+            print(f"  ✓ Hidden: {', '.join(connected_displays)}")
+        else:
+            print("  ✗ Could not hide one or more physical outputs — cleaning up virtual display")
+            _ = run_command(f"sh -c 'echo off > /sys/class/drm/{card_name}-{empty_port}/status'")
+            _ = run_command(f"sh -c 'cat /dev/null > {edid_override_path}'")
+            return False
+
+    # Save state for disconnect (line 4 = edid_override_path for cleanup,
+    # line 5 = Hyprland restore JSON when compositor-safe path was used)
     state_file = SCRIPT_DIR / "virt_display.state"
     _ = state_file.write_text(
-        f"{card_name}\n{empty_port}\n{','.join(connected_displays)}\n{edid_override_path}"
+        f"{card_name}\n{empty_port}\n{','.join(connected_displays)}\n{edid_override_path}\n"
+        f"{json.dumps(hyprland_restore_specs)}"
     )
 
     print(f"\n✓ Virtual display successfully connected!")
@@ -236,58 +288,70 @@ def disconnect() -> bool:
     card_name = state_data[0]
     virtual_port = state_data[1]
     previous_displays = state_data[2].split(",") if len(state_data) > 2 and state_data[2] else []
+    try:
+        hyprland_restore_specs = json.loads(state_data[4]) if len(state_data) > 4 and state_data[4] else {}
+    except json.JSONDecodeError:
+        hyprland_restore_specs = {}
+    hyprland_safe = bool(hyprland_restore_specs)
 
     print(f"  Virtual display: {card_name}-{virtual_port}")
     print(f"  Previous displays: {previous_displays if previous_displays else 'None'}")
 
-    # Step 1: Turn on physical displays FIRST — avoid a zero-output window
-    # that can confuse the compositor (KWin crashes or stops rendering if
-    # all outputs disappear at once).
-    print("\nStep 1: Turning on previous displays...")
-    for disp in previous_displays:
-        if disp:
-            status_path = f"/sys/class/drm/{card_name}-{disp}/status"
-            _ = run_command(f"sh -c 'echo on > {status_path}'")
-            print(f"  ✓ Turned on {disp}")
+    if hyprland_safe:
+        print("\nStep 1: Restoring physical outputs via Hyprland...")
+        if hyprland.restore_outputs(hyprland_restore_specs):
+            print(f"  ✓ Restored: {', '.join(hyprland_restore_specs.keys())}")
+        else:
+            print("\n✗ Hyprland restore failed — state file preserved so disconnect can be retried")
+            return False
+    else:
+        # Turn on physical displays FIRST — avoid a zero-output window
+        # that can confuse the compositor (KWin crashes or stops rendering if
+        # all outputs disappear at once).
+        print("\nStep 1: Turning on previous displays...")
+        for disp in previous_displays:
+            if disp:
+                status_path = f"/sys/class/drm/{card_name}-{disp}/status"
+                _ = run_command(f"sh -c 'echo on > {status_path}'")
+                print(f"  ✓ Turned on {disp}")
 
-    # Step 2: Force CRTC assignment and verify each display is actually up.
-    # On AMD, sysfs hotplug alone doesn't assign CRTCs. Retry up to 3 times
-    # with a short delay; only proceed past this step when all displays are
-    # confirmed active so the state file is never deleted on a partial restore.
-    print("\nStep 2: Restoring physical displays...")
-    all_restored = True
-    for disp in previous_displays:
-        if not disp:
-            continue
+        # Force CRTC assignment and verify each display is actually up.
+        # On AMD, sysfs hotplug alone doesn't assign CRTCs. Retry up to 3 times
+        # with a short delay; only proceed past this step when all displays are
+        # confirmed active so the state file is never deleted on a partial restore.
+        print("\nStep 2: Restoring physical displays...")
+        all_restored = True
+        for disp in previous_displays:
+            if not disp:
+                continue
 
-        restored = False
-        for attempt in range(1, 4):
-            if attempt > 1:
-                print(f"  Retrying {disp} (attempt {attempt}/3)...")
-                time.sleep(2.0)
+            restored = False
+            for attempt in range(1, 4):
+                if attempt > 1:
+                    print(f"  Retrying {disp} (attempt {attempt}/3)...")
+                    time.sleep(2.0)
 
-            ok = force_crtc_assignment(card_name, disp)
-            if ok:
-                ready, mode = wait_for_output_ready(card_name, disp, 0, 0, timeout=5.0)
-                if ready:
-                    print(f"  ✓ {disp} restored ({mode})")
-                    restored = True
-                    break
-                print(f"  ⚠ {disp}: CRTC assigned but compositor has not picked it up yet")
-            else:
-                print(f"  ⚠ {disp}: CRTC assignment failed")
+                ok = force_crtc_assignment(card_name, disp)
+                if ok:
+                    ready, mode = wait_for_output_ready(card_name, disp, 0, 0, timeout=5.0)
+                    if ready:
+                        print(f"  ✓ {disp} restored ({mode})")
+                        restored = True
+                        break
+                    print(f"  ⚠ {disp}: CRTC assigned but compositor has not picked it up yet")
+                else:
+                    print(f"  ⚠ {disp}: CRTC assignment failed")
 
-        if not restored:
-            print(f"  ✗ {disp}: failed to restore after 3 attempts")
-            all_restored = False
+            if not restored:
+                print(f"  ✗ {disp}: failed to restore after 3 attempts")
+                all_restored = False
 
-    if not all_restored:
-        print("\n✗ Not all displays restored — state file preserved so disconnect can be retried")
-        return False
+        if not all_restored:
+            print("\n✗ Not all displays restored — state file preserved so disconnect can be retried")
+            return False
 
-    # Step 3: Release CRTC from virtual display and turn it off
-    print(f"\nStep 3: Releasing CRTC from virtual display ({virtual_port})...")
-    _ = release_crtc(card_name, virtual_port)
+        print(f"\nStep 3: Releasing CRTC from virtual display ({virtual_port})...")
+        _ = release_crtc(card_name, virtual_port)
 
     print(f"\nStep 4: Turning off virtual display ({virtual_port})...")
     status_path = f"/sys/class/drm/{card_name}-{virtual_port}/status"

--- a/src/drm/de/hyprland.py
+++ b/src/drm/de/hyprland.py
@@ -1,0 +1,144 @@
+"""
+Hyprland-specific display helpers.
+
+Hyprland exposes monitor state and configuration through `hyprctl`.  On
+NVIDIA/Hyprland, direct DRM CRTC manipulation can leave physical outputs stuck
+at 0x0 after disconnect, so the display manager uses these helpers to hide and
+restore physical outputs through the compositor instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def find_instance() -> tuple[int, str] | None:
+    """Return (uid, instance_signature) for a running Hyprland session."""
+    run_user = Path("/run/user")
+    if not run_user.exists():
+        return None
+
+    for user_dir in sorted(run_user.iterdir()):
+        if not user_dir.name.isdigit():
+            continue
+        hypr_dir = user_dir / "hypr"
+        if not hypr_dir.exists():
+            continue
+        for inst in sorted(hypr_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+            if (inst / ".socket.sock").exists():
+                return int(user_dir.name), inst.name
+    return None
+
+
+def hyprctl(args: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run hyprctl against the newest visible Hyprland instance."""
+    instance = find_instance()
+    if not instance:
+        return None
+    uid, sig = instance
+    env = os.environ.copy()
+    env["XDG_RUNTIME_DIR"] = f"/run/user/{uid}"
+    return subprocess.run(
+        ["hyprctl", "-i", sig, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def available() -> bool:
+    """Return True when a Hyprland session can be controlled with hyprctl."""
+    result = hyprctl(["status"])
+    return bool(result and result.returncode == 0 and "backend:" in result.stdout)
+
+
+def _bitdepth_from_format(fmt: Any) -> int | None:
+    """Infer Hyprland monitor bitdepth from the active DRM format string."""
+    fmt_text = str(fmt)
+    if "2101010" in fmt_text:
+        return 10
+    if "8888" in fmt_text:
+        return 8
+    return None
+
+
+def monitor_specs(outputs: list[str]) -> dict[str, dict[str, object]]:
+    """Capture enough Hyprland monitor state to restore outputs later."""
+    result = hyprctl(["-j", "monitors", "all"])
+    if not result or result.returncode != 0:
+        return {}
+
+    try:
+        monitors = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+    wanted = set(outputs)
+    specs: dict[str, dict[str, object]] = {}
+    for mon in monitors:
+        name = mon.get("name")
+        if name not in wanted:
+            continue
+        width = mon.get("width")
+        height = mon.get("height")
+        refresh = mon.get("refreshRate")
+        x = mon.get("x", 0)
+        y = mon.get("y", 0)
+        scale = mon.get("scale", 1.0)
+        if not width or not height or not refresh:
+            continue
+
+        spec: dict[str, object] = {
+            "output": name,
+            "mode": f"{width}x{height}@{refresh}",
+            "position": f"{x}x{y}",
+            "scale": scale,
+        }
+
+        bitdepth = _bitdepth_from_format(mon.get("currentFormat"))
+        if bitdepth is not None:
+            spec["bitdepth"] = bitdepth
+
+        if mon.get("vrr") is True:
+            spec["vrr"] = 1
+
+        specs[name] = spec
+    return specs
+
+
+def eval_monitor(spec: dict[str, object]) -> bool:
+    """Apply a Hyprland monitor spec through the Lua-capable hyprctl eval API."""
+    items = []
+    for key, value in spec.items():
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif isinstance(value, (int, float)):
+            rendered = str(value)
+        else:
+            rendered = json.dumps(value)
+        items.append(f"{key} = {rendered}")
+    code = "hl.monitor({ " + ", ".join(items) + " })"
+    result = hyprctl(["eval", code])
+    return bool(result and result.returncode == 0)
+
+
+def disable_outputs(outputs: list[str]) -> bool:
+    """Disable physical outputs through Hyprland."""
+    ok = True
+    for output in outputs:
+        ok = eval_monitor({"output": output, "disabled": True}) and ok
+    return ok
+
+
+def restore_outputs(specs: dict[str, dict[str, object]]) -> bool:
+    """Restore physical outputs through Hyprland."""
+    ok = True
+    for spec in specs.values():
+        restore_spec = dict(spec)
+        restore_spec["disabled"] = False
+        ok = eval_monitor(restore_spec) and ok
+    return ok

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -17,6 +17,13 @@ def _fail_run(cmd: str = "") -> CompletedProcess:
     return CompletedProcess(args=cmd, returncode=1, stdout="", stderr="error")
 
 
+@pytest.fixture(autouse=True)
+def _default_to_legacy_drm_path():
+    """Keep existing tests deterministic on NVIDIA/Hyprland dev machines."""
+    with patch("src.display._use_hyprland_safe_path", return_value=False):
+        yield
+
+
 class TestConnect:
     def _base_patches(self):
         """Return a dict of patch targets with sensible defaults."""
@@ -272,6 +279,64 @@ class TestConnect:
         assert "DP-1" in content
         assert "HDMI-1" in content
 
+    def test_nvidia_hyprland_safe_path_preserves_monitor_options(self, tmp_path):
+        restore_specs = {
+            "DP-1": {
+                "output": "DP-1",
+                "mode": "3440x1440@144.0",
+                "position": "0x0",
+                "scale": 1.0,
+                "bitdepth": 10,
+                "vrr": 1,
+            }
+        }
+        mock_release = MagicMock(return_value=True)
+        mock_force = MagicMock(return_value=True)
+
+        with patch("src.display.SCRIPT_DIR", tmp_path), \
+             patch("src.display._use_hyprland_safe_path", return_value=True), \
+             patch("src.display.hyprland.monitor_specs", return_value=restore_specs), \
+             patch("src.display.hyprland.disable_outputs", return_value=True) as mock_disable, \
+             patch("src.display.get_pixel_clock_info", return_value=(100.0, 655.35, False)), \
+             patch("src.display.get_drm_devices", return_value=[Path("/sys/kernel/debug/dri/0000:01:00.0")]), \
+             patch("src.display.get_card_name_from_device", return_value="card1"), \
+             patch("src.display.get_connected_displays", return_value=["DP-1"]), \
+             patch("src.display.find_empty_slot", return_value=("DP-3", tmp_path)), \
+             patch("src.display.run_command", return_value=_ok_run()), \
+             patch("src.display.release_crtc", mock_release), \
+             patch("src.display.force_crtc_assignment", mock_force), \
+             patch("src.display.wait_for_output_ready", return_value=(True, "1280x800")), \
+             patch("src.display.clear_kwin_output_config"), \
+             patch("src.display.create_edid", return_value=b"\x00" * 256):
+            result = connect(1280, 800, 60)
+
+        assert result is True
+        mock_release.assert_not_called()
+        mock_force.assert_not_called()
+        mock_disable.assert_called_once_with(["DP-1"])
+        content = (tmp_path / "virt_display.state").read_text()
+        assert '"bitdepth": 10' in content
+        assert '"vrr": 1' in content
+
+    def test_nvidia_hyprland_safe_path_refuses_without_restore_specs(self, tmp_path):
+        mock_run = MagicMock(return_value=_ok_run())
+        with patch("src.display.SCRIPT_DIR", tmp_path), \
+             patch("src.display._use_hyprland_safe_path", return_value=True), \
+             patch("src.display.hyprland.monitor_specs", return_value={}), \
+             patch("src.display.get_pixel_clock_info", return_value=(100.0, 655.35, False)), \
+             patch("src.display.get_drm_devices", return_value=[Path("/sys/kernel/debug/dri/0000:01:00.0")]), \
+             patch("src.display.get_card_name_from_device", return_value="card1"), \
+             patch("src.display.get_connected_displays", return_value=["DP-1"]), \
+             patch("src.display.find_empty_slot", return_value=("DP-3", tmp_path)), \
+             patch("src.display.run_command", mock_run), \
+             patch("src.display.clear_kwin_output_config"), \
+             patch("src.display.create_edid", return_value=b"\x00" * 256):
+            result = connect(1280, 800, 60)
+
+        assert result is False
+        cmds = [call_args[0][0] for call_args in mock_run.call_args_list]
+        assert not any("echo off > /sys/class/drm/card1-DP-1/status" in c for c in cmds)
+
 
 class TestDisconnect:
     def _write_state(self, path: Path, card: str, port: str, displays: list[str]) -> None:
@@ -376,3 +441,21 @@ class TestDisconnect:
              patch("src.display.release_crtc", return_value=True):
             disconnect()
         assert mock_force.call_count == 2
+
+    def test_hyprland_restore_path_skips_crtc_forcing(self, tmp_path):
+        restore_json = '{"DP-1":{"output":"DP-1","mode":"3440x1440@144.0","position":"0x0","scale":1.0,"bitdepth":10,"vrr":1}}'
+        (tmp_path / "virt_display.state").write_text(
+            f"card1\nDP-3\nDP-1\n{tmp_path / 'DP-3' / 'edid_override'}\n{restore_json}"
+        )
+        mock_restore = MagicMock(return_value=True)
+        mock_force = MagicMock(return_value=True)
+        with patch("src.display.SCRIPT_DIR", tmp_path), \
+             patch("src.display.hyprland.restore_outputs", mock_restore), \
+             patch("src.display.run_command", return_value=_ok_run()), \
+             patch("src.display.force_crtc_assignment", mock_force), \
+             patch("src.display.release_crtc", return_value=True):
+            result = disconnect()
+
+        assert result is True
+        mock_restore.assert_called_once()
+        mock_force.assert_not_called()

--- a/tests/test_hyprland.py
+++ b/tests/test_hyprland.py
@@ -1,0 +1,106 @@
+"""Tests for Hyprland-specific display helpers."""
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+from src.drm.de import hyprland
+
+
+def _hyprctl_result(payload: object) -> CompletedProcess:
+    return CompletedProcess(args="hyprctl", returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def test_monitor_specs_uses_hyprctl_json_and_preserves_10_bit():
+    monitors = [
+        {
+            "name": "DP-1",
+            "width": 3440,
+            "height": 1440,
+            "refreshRate": 144.0,
+            "x": 0,
+            "y": 0,
+            "scale": 1.0,
+            "currentFormat": "XBGR2101010",
+            "vrr": False,
+        }
+    ]
+
+    with patch("src.drm.de.hyprland.hyprctl", return_value=_hyprctl_result(monitors)):
+        assert hyprland.monitor_specs(["DP-1"]) == {
+            "DP-1": {
+                "output": "DP-1",
+                "mode": "3440x1440@144.0",
+                "position": "0x0",
+                "scale": 1.0,
+                "bitdepth": 10,
+            }
+        }
+
+
+def test_monitor_specs_handles_8_bit_outputs():
+    monitors = [
+        {
+            "name": "DP-2",
+            "width": 1920,
+            "height": 1200,
+            "refreshRate": 59.95,
+            "x": 3440,
+            "y": 0,
+            "scale": 1.0,
+            "currentFormat": "XRGB8888",
+            "vrr": False,
+        }
+    ]
+
+    with patch("src.drm.de.hyprland.hyprctl", return_value=_hyprctl_result(monitors)):
+        assert hyprland.monitor_specs(["DP-2"])["DP-2"]["bitdepth"] == 8
+
+
+def test_monitor_specs_preserves_active_vrr_when_config_has_no_policy():
+    monitors = [
+        {
+            "name": "DP-1",
+            "width": 3440,
+            "height": 1440,
+            "refreshRate": 144.0,
+            "x": 0,
+            "y": 0,
+            "scale": 1.0,
+            "currentFormat": "XBGR2101010",
+            "vrr": True,
+        }
+    ]
+
+    with patch("src.drm.de.hyprland.hyprctl", return_value=_hyprctl_result(monitors)):
+        assert hyprland.monitor_specs(["DP-1"])["DP-1"]["vrr"] == 1
+
+
+
+def test_restore_outputs_includes_disabled_false_and_monitor_options():
+    mock_eval = MagicMock(return_value=True)
+    specs = {
+        "DP-1": {
+            "output": "DP-1",
+            "mode": "3440x1440@144.0",
+            "position": "0x0",
+            "scale": 1.0,
+            "bitdepth": 10,
+            "vrr": 1,
+        }
+    }
+
+    with patch("src.drm.de.hyprland.eval_monitor", mock_eval):
+        assert hyprland.restore_outputs(specs) is True
+
+    mock_eval.assert_called_once_with(
+        {
+            "output": "DP-1",
+            "mode": "3440x1440@144.0",
+            "position": "0x0",
+            "scale": 1.0,
+            "bitdepth": 10,
+            "vrr": 1,
+            "disabled": False,
+        }
+    )


### PR DESCRIPTION
## Summary
- avoid direct DRM CRTC release/force paths on NVIDIA + Hyprland
- use Hyprland monitor commands to hide/restore physical outputs safely
- preserve monitor options such as bitdepth and vrr in restore state
- add regression tests for the safe path and restore behavior

## Validation
- python3 -m py_compile src/display.py tests/test_display.py
- python3 -m pytest -q could not be run locally: pytest is not installed in this environment

## Context
Direct DRM CRTC manipulation on NVIDIA/Hyprland can leave a physical output restored as 0x0 after a Sunshine session ends. This keeps the legacy DRM path for other setups but uses compositor-safe monitor operations where Hyprland is available on NVIDIA.